### PR TITLE
Remove requirements "tech"

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -3,7 +3,7 @@
   "name": "Tech Controllers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tech",
-  "requirements": ["tech"],
+  "requirements": [],
   "dependencies": [],
   "codeowners": [
     "@mariusz.ostoja-swierczynski"


### PR DESCRIPTION
After upgrade HA to 2022.10.3 version I got Error of tech integration :( Seems like in the manifest.json is rnon existent package. Removing it fixes the error and allows the integration to load